### PR TITLE
add --ssh-opts arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ssh-add ~/.ec2/development.pem</code></pre>
 
 ###Usage
 
-Once configuration is complete, you can run the script: <code>python fofum.py</code>
+Once configuration is complete, you can run the script.  Your working directory must be the directory fofum.py is in: <code>python fofum.py</code>
 
 You must first select the environment:
 <pre><code>Environments:
@@ -36,7 +36,7 @@ You must first select the environment:
  2 - staging
  3 - development
  0 - Exit
- 
+
 Choose an environment:</code></pre>
 
 Then, the instance:
@@ -47,7 +47,7 @@ Then, the instance:
  3 - my-3rd-instance.compute-1.amazonaws.com
  4 - my-4th-instance.compute-1.amazonaws.com
  0 - Exit
- 
+
 Choose an instance:</code></pre>
 
 You will then be connected to the instance using the ec2-user key you added during configuration.

--- a/fofum.py
+++ b/fofum.py
@@ -1,3 +1,4 @@
+import argparse
 import boto
 import commands
 import os
@@ -52,7 +53,7 @@ def get_env():
 
   return env
 
-def get_instance(env):
+def get_instance(env, ssh_args=''):
   resources = commands.getoutput(
     './aws/api/bin/elastic-beanstalk-describe-environment-resources ' + \
       '-e %s 2>/dev/null' \
@@ -79,17 +80,29 @@ def get_instance(env):
       dns_names,
       'instances (%s):' % env, 'instance'
     )
-    os.system('ssh ec2-user@%s' % instance)
+    _ssh(instance, ssh_args)
+
+
+def _ssh(ip='', args=''):
+  user = 'ec2-user'
+  if args:
+    os.system('ssh %s %s@%s' % (args, user, ip))
+  else:
+    os.system('ssh %s@%s' % (user, ip))
+
 
 def main():
   os.putenv(
     'AWS_CREDENTIAL_FILE',
     os.path.expanduser('~/.elasticbeanstalk.cfg')
   )
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-ssh-opts', '--ssh-opts', dest='ssh_args')
+  args = parser.parse_args()
 
   display_intro()
   env = get_env()
-  get_instance(env)
+  get_instance(env, ssh_args=args.ssh_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I keep the VPC config in a separate ssh config file, this allows
passing ssh options thru like so:

  python fofum.py --ssh-opts="-F ~/.ssh/config-for-vpc"

also update the readme to note that it's got to run from fofum.py's
directory

long live fofum.py!
